### PR TITLE
apidoc: apidoc_formatting: Fixed double Fig in images

### DIFF
--- a/sphinx_immaterial/apidoc/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc/apidoc_formatting.py
@@ -61,11 +61,14 @@ def visit_caption(
         # This is needed to trigger mkdocs-material CSS rule `.highlight .filename`
         self.body.append('<div class="code-block-caption highlight">')
         # append a CSS class to trigger mkdocs-material theme's caption CSS style
-        attributes["class"] += " filename"
+        self.body.append('<span class="filename">')
+        # append a listing number
+        self.add_fignumber(node.parent)
+        self.body.append(self.starttag(node, "span", **attributes))
+        self.body.append("</span>")
     else:
         super_func(self, node)
-    self.add_fignumber(node.parent)
-    self.body.append(self.starttag(node, "span", **attributes))
+        self.body.append(self.starttag(node, "span", **attributes))
 
 
 @html_translator_mixin.override


### PR DESCRIPTION
The explicit `add_fignumber` seems to be excessive - it creates double `Fig` entries in rendered doc, and also add raw explicit `Listing` string before code blocks.

The `add_fignumber` needs to be called explicitly for code blocks, and in this particular scenario we also need to wrap this call in `<span>` of class `filename` so the formatting of Listing ID and Listing's caption are the same.